### PR TITLE
Make the pip console script for FileXor work. Fixes #1.

### DIFF
--- a/FileXor/__main__.py
+++ b/FileXor/__main__.py
@@ -15,6 +15,11 @@ from docopt import docopt
 from FileXor import fkrandxor, fxor
 
 
+def cli():
+    args = docopt(__doc__, version='File XOR Utility 0.2.1.a1')
+    main(args)
+
+
 def main(args):
     """Program entry point.
 
@@ -35,5 +40,4 @@ def main(args):
         fkrandxor(args['<key>'], args['<infile>'], args['<outfile>'])
 
 if __name__ == '__main__':
-    args = docopt(__doc__, version='File XOR Utility 0.2.1.a1')
-    main(args)
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     },
     entry_points={
         'console_scripts': [
-            'FileXor=filexor.py:main',
+            'FileXor=FileXor.__main__:cli',
         ]
     }
 )


### PR DESCRIPTION
Move the bin/filexor.py file into the FileXor module as **main**.py and
encapsulate the if **name** == '**main**' functionality in an entry
point called cli().
